### PR TITLE
Include additional benchmarks for primitive collections and other forms of iteration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ test {
 
 dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.6.+')
+    implementation 'it.unimi.dsi:fastutil:8.3.1'
 }
 
 jmh {

--- a/src/jmh/java/cpw/mods/performancetests/TestComplexStreams.java
+++ b/src/jmh/java/cpw/mods/performancetests/TestComplexStreams.java
@@ -1,26 +1,79 @@
 package cpw.mods.performancetests;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.openjdk.jmh.annotations.Benchmark;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class TestComplexStreams {
-    public static List<Integer> testList = IntStream.range(1, 1000).boxed().collect(Collectors.toList());
+    public static final List<Integer> testListBoxed = IntStream.range(1, 1000).boxed().collect(Collectors.toList());
+    public static final IntList testList = new IntArrayList(testListBoxed);
+    public static final int[] testArray = testList.toIntArray();
+    public static final int[] constants = { 2, 4 };
 
     @Benchmark
-    public int testExplicitStream() {
-        int[] constants = { 2, 4 };
+    public int testBoxedListStream() {
+        return testListBoxed.stream().mapToInt(Integer::intValue).map(i->constants[i&1]*i).sum();
+    }
+    @Benchmark
+    public int testBoxedListIndexedFor() {
+        int sum = 0;
+        for (int i2 = 0, testListSize = testListBoxed.size(); i2 < testListSize; i2++) {
+            int i = testListBoxed.get(i2);
+            int i1 = constants[i&1] * i;
+            sum += i1;
+        }
+        return sum;
+    }
+    @Benchmark
+    public int testBoxedListIteratorFor() {
+        int sum = 0;
+        for (Integer integer : testListBoxed) {
+            int i = integer;
+            int i1 = constants[i & 1] * i;
+            sum += i1;
+        }
+        return sum;
+    }
+    @Benchmark
+    public int testPrimitiveListStream() {
         return testList.stream().mapToInt(Integer::intValue).map(i->constants[i&1]*i).sum();
     }
     @Benchmark
-    public int testIndexedFor() {
-        int[] constants = { 2, 4 };
+    public int testPrimitiveArrayStream() {
+        return Arrays.stream(testArray).map(i->constants[i&1]*i).sum();
+    }
+    @Benchmark
+    public int testPrimitiveArrayIndexed() {
+        int sum = 0;
+        for (int i : testArray) {
+            int i1 = constants[i & 1] * i;
+            sum += i1;
+        }
+        return sum;
+    }
+    @Benchmark
+    public int testPrimitiveListIndexedFor() {
         int sum = 0;
         for (int i2 = 0, testListSize = testList.size(); i2 < testListSize; i2++) {
-            int i = testList.get(i2).intValue();
+            int i = testList.getInt(i2);
             int i1 = constants[i&1] * i;
+            sum += i1;
+        }
+        return sum;
+    }
+    @Benchmark
+    public int testPrimitiveListIteratorWhile() {
+        int sum = 0;
+        IntIterator it = testList.iterator();
+        while (it.hasNext()) {
+            int i = it.nextInt();
+            int i1 = constants[i & 1] * i;
             sum += i1;
         }
         return sum;

--- a/src/jmh/java/cpw/mods/performancetests/TestConsumerStream.java
+++ b/src/jmh/java/cpw/mods/performancetests/TestConsumerStream.java
@@ -8,16 +8,40 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class TestConsumerStream {
-    public static List<Integer> testList = IntStream.range(1, 1000).boxed().collect(Collectors.toList());
-    public static int[] ints = testList.stream().mapToInt(Integer::intValue).toArray();
+    public static final List<Integer> testList = IntStream.range(1, 1000).boxed().collect(Collectors.toList());
+
+    public static final int[] ints = testList.stream().mapToInt(Integer::intValue).toArray();
+
     @Benchmark
-    public int testStream() {
-        return Arrays.stream(ints).map(this::multiply).sum();
-//        return testList.stream().mapToInt(Integer::intValue).map(this::multiply).sum();
+    public int testBoxedListStream() {
+        return testList.stream().mapToInt(Integer::intValue).map(TestConsumerStream::multiply).sum();
     }
 
     @Benchmark
-    public int testFor() {
+    public int testBoxedListIndexedFor() {
+        int sum = 0;
+        for (int i = 0, testListSize = testList.size(); i < testListSize; i++) {
+            sum += multiply(testList.get(i));
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int testBoxedListIteratorFor() {
+        int sum = 0;
+        for (Integer anInt : testList) {
+            sum += multiply(anInt);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int testPrimitiveArrayStream() {
+        return Arrays.stream(ints).map(TestConsumerStream::multiply).sum();
+    }
+
+    @Benchmark
+    public int testPrimitiveArrayIndexedFor() {
         int sum = 0;
         for (int i = 0, testListSize = ints.length; i < testListSize; i++) {
             sum += multiply(ints[i]);
@@ -25,7 +49,16 @@ public class TestConsumerStream {
         return sum;
     }
 
-    public int multiply(int val) {
+    @Benchmark
+    public int testPrimitiveArrayIteratorFor() {
+        int sum = 0;
+        for (int anInt : ints) {
+            sum += multiply(anInt);
+        }
+        return sum;
+    }
+
+    public static int multiply(int val) {
         return val * 2;
     }
 }

--- a/src/jmh/java/cpw/mods/performancetests/TestStreams.java
+++ b/src/jmh/java/cpw/mods/performancetests/TestStreams.java
@@ -1,52 +1,88 @@
 package cpw.mods.performancetests;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 public class TestStreams {
-    public static List<Integer> testList = IntStream.range(1, 1000).boxed().collect(Collectors.toList());
-    public static Integer[] arrayList = testList.toArray(new Integer[0]);
-    public static Integer[] tst = IntStream.range(1, 1000).boxed().toArray(Integer[]::new);
+    public static final List<Integer> boxedIntList = IntStream.range(1, 1000).boxed().collect(Collectors.toList());
+    public static final Integer[] boxedIntArray = boxedIntList.toArray(new Integer[0]);
+    public static final IntList intList = new IntArrayList(boxedIntList);
+    public static final int[] intArray = intList.toIntArray();
+    public static final Integer[] tst = IntStream.range(1, 1000).boxed().toArray(Integer[]::new);
 
     @Benchmark
-    public int testExplicitStream(Blackhole bh) {
-        return testList.stream().mapToInt(Integer::intValue).sum();
+    public int testBoxedListStream(Blackhole bh) {
+        return boxedIntList.stream().mapToInt(Integer::intValue).sum();
     }
     @Benchmark
-    public int testArrayStream(Blackhole bh) {
-        return Arrays.stream(arrayList).mapToInt(Integer::intValue).sum();
+    public int testBoxedArrayStream(Blackhole bh) {
+        return Arrays.stream(boxedIntArray).mapToInt(Integer::intValue).sum();
     }
     @Benchmark
-    public int testIteratorFor(Blackhole bh) {
+    public int testBoxedListIteratorFor(Blackhole bh) {
         int sum = 0;
-        for (Integer i : testList) {
-            sum += i.intValue();
+        for (Integer i : boxedIntList) {
+            sum += i;
         }
         return sum;
     }
     @Benchmark
-    public int testIndexedFor(Blackhole bh) {
+    public int testBoxedListIndexedFor(Blackhole bh) {
         int sum = 0;
-        for (int i1 = 0, testListSize = testList.size(); i1 < testListSize; i1++) {
-            sum += testList.get(i1).intValue();
+        for (int i1 = 0, testListSize = boxedIntList.size(); i1 < testListSize; i1++) {
+            sum += boxedIntList.get(i1);
         }
         return sum;
     }
     @Benchmark
-    public int testWhileArray(Blackhole bh) {
+    public int testBoxedArrayWhile(Blackhole bh) {
         int sum = 0;
-        int i1 = 0, testListSize = arrayList.length;
+        int i1 = 0, testListSize = boxedIntArray.length;
         while (i1 < testListSize) {
-            sum += arrayList[i1].intValue();
+            sum += boxedIntArray[i1];
             i1++;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int testPrimitiveListStream(Blackhole bh) {
+        return intList.stream().mapToInt(Integer::intValue).sum();
+    }
+    @Benchmark
+    public int testPrimitiveArrayStream(Blackhole bh) {
+        return Arrays.stream(intArray).sum();
+    }
+    @Benchmark
+    public int testPrimitiveListIteratorWhile(Blackhole bh) {
+        int sum = 0;
+        IntIterator it = intList.iterator();
+        while (it.hasNext()) {
+            sum += it.nextInt();
+        }
+        return sum;
+    }
+    @Benchmark
+    public int testPrimitiveListIndexedFor(Blackhole bh) {
+        int sum = 0;
+        for (int i1 = 0, testListSize = intList.size(); i1 < testListSize; i1++) {
+            sum += intList.getInt(i1);
+        }
+        return sum;
+    }
+    @Benchmark
+    public int testPrimitiveArrayIteratorFor(Blackhole bh) {
+        int sum = 0;
+        for (int i : intArray) {
+            sum += i;
         }
         return sum;
     }


### PR DESCRIPTION
A number of benchmarks in this suite involve [integer boxing](https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html) because the Java standard library does not support generic collections over primitive types. This requires that each value in the collection is of a boxed integer type (requiring a heap allocation and significantly more memory) and that each object is de-referenced whenever operating upon them, which in turn prevents effective utilization of the CPU's cache lines. 

It is often the case when writing high-performance code that one will end up using type-specific collection types when dealing with collections over primitive values. Minecraft (as a semi-relevant example) makes heavy use of such optimized collection types from [DSI's FastUtil library](http://fastutil.di.unimi.it/).

This pull request extends the existing benchmarks to include a variant which operates on primitive collections, removing the associated overhead. The benchmark names have been prefixed to indicate whether or not they operate on boxed or primitive types. Additionally, some additional benchmarks have been added which use the (likely first choice) for-each approach.

I have compiled the benchmark results after these changes [in this Gist](https://gist.github.com/jellysquid3/478cd233d0a9b0506d4954429e96f5fb). In benchmark runs where optimal collection types are used, traditional iteration is considerably speedier than the fastest variants for the boxed version of the test. 

However, the numbers tend to favor traditional iteration over the comparable stream code because each value needs to now be boxed. I've included a number of benchmarks which try to avoid this overhead through creating primitive arrays which can be streamed using an optimized IntStream, but this hides the fact that copying the array would probably introduce a significant hit to performance and would probably not be done in most code.

I believe this is a rather important (and interesting) point of consideration when it comes to writing fast code limited by iteration throughput. Regardless of using streams or not with boxed integer types, the code will be vastly slower than what the comparable non-boxed variant would otherwise be.